### PR TITLE
feat(kyc): add endpoint to fetch KYC records by status

### DIFF
--- a/prs/prs-rest-api/src/main/java/com/adorsys/webank/KycRestApi.java
+++ b/prs/prs-rest-api/src/main/java/com/adorsys/webank/KycRestApi.java
@@ -1,17 +1,13 @@
 package com.adorsys.webank;
 
-import com.adorsys.webank.domain.PersonalInfoEntity;
 import com.adorsys.webank.dto.*;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpHeaders;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.*;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-import com.adorsys.webank.domain.UserDocumentsEntity;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Tag(name = "KYC", description = "Operations related to KYC processing")
 @RequestMapping("/api/prs/kyc")
@@ -53,16 +49,16 @@ public interface KycRestApi {
     @PostMapping(value = "/email", consumes = "application/json", produces = "application/json")
     String sendKycEmail(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody KycEmailRequest kycEmailRequest);
 
-    @Operation(summary = "Get User Documents", description = "Fetches user documents based on the provided public key hash. The response includes relevant documents if found.")
+    @Operation(summary = "Get Pending KYC Records",
+            description = "Fetches all KYC records with PENDING status")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "User documents successfully retrieved"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid token"),
-            @ApiResponse(responseCode = "404", description = "User documents not found"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Pending records retrieved"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "Internal error")
     })
-
-    @GetMapping(value = "/infos", produces = "application/json")
-    List<PersonalInfoEntity> getPersonalInfoByStatus(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader);
+    @GetMapping(value = "/pending", produces = "application/json")
+    List<UserInfoResponse> getPendingKycRecords(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader);
 
     @Operation(summary = "Get pending OTPs", description = "Fetches all pending OTPs where registration is not complete. The response includes the phone number, a masked version of the OTP, and the registration status.")
     @ApiResponses(value = {
@@ -74,10 +70,6 @@ public interface KycRestApi {
     List<UserInfoResponse> findByDocumentUniqueId(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
                                                   @PathVariable("DocumentUniqueId") String DocumentUniqueId);
 
-
-    @PostMapping(value = "/record", consumes = "application/json", produces = "application/json")
-    Optional<UserDocumentsEntity> getDocuments(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody KycGetDocRequest kycGetDocRequest);
-
-
 }
+
+

--- a/prs/prs-rest-server/src/main/java/com/adorsys/webank/KycRestServer.java
+++ b/prs/prs-rest-server/src/main/java/com/adorsys/webank/KycRestServer.java
@@ -1,19 +1,12 @@
 package com.adorsys.webank;
 
-import com.adorsys.webank.domain.PersonalInfoEntity;
-import com.adorsys.webank.domain.PersonalInfoStatus;
 import com.adorsys.webank.dto.*;
-import com.adorsys.webank.security.CertValidator;
-import com.adorsys.webank.security.JwtValidator;
-import com.adorsys.webank.service.KycServiceApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.RestController;
-import com.adorsys.webank.dto.KycDocumentRequest;
-import com.adorsys.webank.domain.UserDocumentsEntity;
+import com.adorsys.webank.security.*;
+import com.adorsys.webank.service.*;
+import org.slf4j.*;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @RestController
 public class KycRestServer implements KycRestApi {
@@ -26,152 +19,107 @@ public class KycRestServer implements KycRestApi {
         this.certValidator = certValidator;
     }
 
-
     @Override
     public String sendKycinfo(String authorizationHeader, KycInfoRequest kycInfoRequest) {
-        String jwtToken;
-
         try {
-            // Extract the JWT token from the Authorization header
-            jwtToken = extractJwtFromHeader(authorizationHeader);
-            JwtValidator.validateAndExtract(jwtToken, kycInfoRequest.getIdNumber(),kycInfoRequest.getExpiryDate(), kycInfoRequest.getAccountId());
-            log.info("Successfully validated sendinfo");
-
-            // Validate the JWT token using the injected CertValidator instance
+            String jwtToken = extractJwtFromHeader(authorizationHeader);
+            log.info("jwtToken from sending info is: {}, for accountId: {}", jwtToken, kycInfoRequest.getAccountId());
+            JwtValidator.validateAndExtract(jwtToken, kycInfoRequest.getIdNumber(), kycInfoRequest.getExpiryDate(), kycInfoRequest.getAccountId());
             if (!certValidator.validateJWT(jwtToken)) {
-
-                return "Invalid or unauthorized JWT.";
+                throw new SecurityException("Invalid or unauthorized JWT.");
             }
+
+            return kycServiceApi.sendKycinfo(kycInfoRequest.getAccountId(), kycInfoRequest);
         } catch (Exception e) {
             return "Invalid JWT: " + e.getMessage();
         }
-
-        String AccountId = kycInfoRequest.getAccountId();
-
-        return kycServiceApi.sendKycinfo( AccountId, kycInfoRequest);
     }
 
     @Override
     public String sendKyclocation(String authorizationHeader, KycLocationRequest kycLocationRequest) {
-        String jwtToken;
-
-        String location = kycLocationRequest.getLocation();
         try {
-            // Extract the JWT token from the Authorization header
-            jwtToken = extractJwtFromHeader(authorizationHeader);
-            JwtValidator.validateAndExtract(jwtToken, location, kycLocationRequest.getAccountId());
-
-            // Validate the JWT token using the injected CertValidator instance
+            String jwtToken = extractJwtFromHeader(authorizationHeader);
+            log.info("jwtToken from sending location is: {}, for accountId: {}", jwtToken, kycLocationRequest.getAccountId());
+            JwtValidator.validateAndExtract(jwtToken, kycLocationRequest.getLocation(), kycLocationRequest.getAccountId());
             if (!certValidator.validateJWT(jwtToken)) {
-
-                return "Invalid or unauthorized JWT.";
+                throw new SecurityException("Invalid or unauthorized JWT.");
             }
+
+            return kycServiceApi.sendKyclocation(kycLocationRequest);
         } catch (Exception e) {
             return "Invalid JWT: " + e.getMessage();
         }
-
-        return kycServiceApi.sendKyclocation( kycLocationRequest);
     }
 
     @Override
     public String sendKycEmail(String authorizationHeader, KycEmailRequest kycEmailRequest) {
-        String jwtToken;
-
         try {
-            // Extract the JWT token from the Authorization header
-            jwtToken = extractJwtFromHeader(authorizationHeader);
+            String jwtToken = extractJwtFromHeader(authorizationHeader);
+            log.info("jwtToken from user sending email is  : {}", jwtToken);
             JwtValidator.validateAndExtract(jwtToken);
-
-            // Validate the JWT token using the injected CertValidator instance
             if (!certValidator.validateJWT(jwtToken)) {
-
-                return "Invalid or unauthorized JWT.";
+                throw new SecurityException("Invalid or unauthorized JWT.");
             }
+
+            return kycServiceApi.sendKycEmail(kycEmailRequest);
         } catch (Exception e) {
             return "Invalid JWT: " + e.getMessage();
         }
-
-        return kycServiceApi.sendKycEmail( kycEmailRequest);
-    }
-
-    @Override
-    public List<PersonalInfoEntity>  getPersonalInfoByStatus(String authorizationHeader) {
-        String jwtToken;
-        try {
-            // Extract the JWT token from the Authorization header
-            jwtToken = extractJwtFromHeader(authorizationHeader);
-            JwtValidator.validateAndExtract(jwtToken);
-            log.info("Success");
-
-        } catch (Exception e) {
-            throw new IllegalArgumentException("An error occurred");
-        }
-        return kycServiceApi.getPersonalInfoByStatus(PersonalInfoStatus.valueOf("PENDING"));
-    }
-
-    @Override
-    public List<UserInfoResponse> findByDocumentUniqueId(String authorizationHeader, String DocumentUniqueId) {
-//        String jwtToken;
-        try {
-            // Extract the JWT token from the Authorization header
-//            jwtToken = extractJwtFromHeader(authorizationHeader);
-//            JwtValidator.validateAndExtract(jwtToken);
-            log.info("Success");
-
-        } catch (Exception e) {
-            throw new IllegalArgumentException("An error occurred");
-        }
-        return kycServiceApi.findByDocumentUniqueId(DocumentUniqueId);
-
     }
 
     @Override
     public String sendKycDocument(String authorizationHeader, KycDocumentRequest kycDocumentRequest) {
-        String jwtToken;
-
-
         try {
-            // Extract the JWT token from the Authorization header
-            jwtToken = extractJwtFromHeader(authorizationHeader);
-            JwtValidator.validateAndExtract(jwtToken,  kycDocumentRequest.getFrontId(),kycDocumentRequest.getBackId(), kycDocumentRequest.getSelfieId()
-                    , kycDocumentRequest.getTaxId(), kycDocumentRequest.getAccountId());
-            log.info("Successfully validated sendinfo");
+            String jwtToken = extractJwtFromHeader(authorizationHeader);
+            log.info("jwtToken from sending document is: {}, for accountId: {}", jwtToken, kycDocumentRequest.getAccountId());
+            JwtValidator.validateAndExtract(jwtToken,
+                    kycDocumentRequest.getFrontId(), kycDocumentRequest.getBackId(),
+                    kycDocumentRequest.getSelfieId(), kycDocumentRequest.getTaxId(),
+                    kycDocumentRequest.getAccountId());
 
-
-            // Validate the JWT token using the injected CertValidator instance
             if (!certValidator.validateJWT(jwtToken)) {
-
-                return "Invalid or unauthorized JWT.";
+                throw new SecurityException("Invalid or unauthorized JWT.");
             }
+
+            return kycServiceApi.sendKycDocument(kycDocumentRequest.getAccountId(), kycDocumentRequest);
         } catch (Exception e) {
             return "Invalid JWT: " + e.getMessage();
         }
-
-        String AccountId = kycDocumentRequest.getAccountId();
-        return kycServiceApi.sendKycDocument(AccountId, kycDocumentRequest);
     }
-
 
     @Override
-    public Optional<UserDocumentsEntity> getDocuments(String authorizationHeader, KycGetDocRequest kycGetDocRequest) {
-        String jwtToken;
-        String accountId = kycGetDocRequest.getAccountId();
+    public List<UserInfoResponse> getPendingKycRecords(String authorizationHeader) {
         try {
-            // Extract the JWT token from the Authorization header
-            jwtToken = extractJwtFromHeader(authorizationHeader);
-            JwtValidator.validateAndExtract(jwtToken, accountId);
+            String jwtToken = extractJwtFromHeader(authorizationHeader);
+            log.info("jwtToken from agent doing verification is : {}", jwtToken);
+            JwtValidator.validateAndExtract(jwtToken);
 
-            log.info("Fetching documents for public key hash: {}", accountId);
+            if (!certValidator.validateJWT(jwtToken)) {
+                throw new SecurityException("Invalid or unauthorized JWT.");
+            }
+
+            return kycServiceApi.getPendingKycRecords();
         } catch (Exception e) {
-            log.error("Error extracting JWT token or fetching documents for accountid: {}", accountId, e);
-            throw new IllegalArgumentException("An error occurred while fetching documents.");
+            throw new IllegalArgumentException("JWT validation failed: " + e.getMessage());
         }
-        // Delegate to the service to retrieve user documents
-        return kycServiceApi.getDocuments(accountId);
     }
 
+    @Override
+    public List<UserInfoResponse> findByDocumentUniqueId(String authorizationHeader, String DocumentUniqueId) {
+        try {
+            String jwtToken = extractJwtFromHeader(authorizationHeader);
+            log.info("jwtToken from agent doing recovery is : {}", jwtToken);
+            JwtValidator.validateAndExtract(jwtToken, DocumentUniqueId);
 
+            if (!certValidator.validateJWT(jwtToken)) {
+                throw new SecurityException("Invalid or unauthorized JWT.");
+            }
 
+            return kycServiceApi.findByDocumentUniqueId(DocumentUniqueId);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("JWT validation failed: " + e.getMessage());
+        }
+    }
 
     private String extractJwtFromHeader(String authorizationHeader) {
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
@@ -179,6 +127,4 @@ public class KycRestServer implements KycRestApi {
         }
         return authorizationHeader.substring(7); // Remove "Bearer " prefix
     }
-
-
 }

--- a/prs/prs-service-api/src/main/java/com/adorsys/webank/service/KycServiceApi.java
+++ b/prs/prs-service-api/src/main/java/com/adorsys/webank/service/KycServiceApi.java
@@ -1,15 +1,10 @@
 package com.adorsys.webank.service;
-import com.adorsys.webank.domain.PersonalInfoEntity;
-import com.adorsys.webank.domain.PersonalInfoStatus;
-import com.adorsys.webank.dto.KycEmailRequest;
-import com.adorsys.webank.dto.KycInfoRequest;
-import com.adorsys.webank.dto.KycLocationRequest;
-import org.springframework.stereotype.Service;
-import com.adorsys.webank.dto.UserInfoResponse;
-import java.util.List;
-import java.util.Optional;
-import com.adorsys.webank.dto.KycDocumentRequest;
-import com.adorsys.webank.domain.UserDocumentsEntity;
+
+import com.adorsys.webank.domain.*;
+import com.adorsys.webank.dto.*;
+import org.springframework.stereotype.*;
+
+import java.util.*;
 
 @Service
 public interface KycServiceApi {
@@ -17,8 +12,7 @@ public interface KycServiceApi {
     String sendKycinfo( String AccountId, KycInfoRequest kycInfoRequest);
     String sendKyclocation( KycLocationRequest kycLocationRequest);
     String sendKycEmail(KycEmailRequest kycEmailRequest);
-    Optional<UserDocumentsEntity> getDocuments(String accountId);
     Optional<PersonalInfoEntity> getPersonalInfoAccountId(String accountId);
-    List<PersonalInfoEntity> getPersonalInfoByStatus(PersonalInfoStatus status);
+    List<UserInfoResponse> getPendingKycRecords();
     List<UserInfoResponse> findByDocumentUniqueId(String documentUniqueId);
 }

--- a/prs/prs-service-impl/src/main/java/com/adorsys/webank/serviceimpl/KycStatusUpdateServiceImpl.java
+++ b/prs/prs-service-impl/src/main/java/com/adorsys/webank/serviceimpl/KycStatusUpdateServiceImpl.java
@@ -1,15 +1,13 @@
 package com.adorsys.webank.serviceimpl;
 
-import com.adorsys.webank.domain.PersonalInfoEntity;
-import com.adorsys.webank.domain.PersonalInfoStatus;
-import com.adorsys.webank.repository.PersonalInfoRepository;
-import com.adorsys.webank.service.KycStatusUpdateServiceApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.adorsys.webank.domain.*;
+import com.adorsys.webank.repository.*;
+import com.adorsys.webank.service.*;
+import org.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class KycStatusUpdateServiceImpl implements KycStatusUpdateServiceApi {


### PR DESCRIPTION
- Create a new endpoint `"/pending"` to fetch KYC records by status.
- Implement filtering logic in the service layer to query records by status.
- Ensure only records with the specified status (e.g., "PENDING") are returned.
- Remove endpoints that where not use by frontend