### PR TITLE
Fix issue with Base64 image storage by updating DB columns to TEXT type

### DIFF
--- a/prs/prs-db-repository/src/main/java/com/adorsys/webank/domain/UserDocumentsEntity.java
+++ b/prs/prs-db-repository/src/main/java/com/adorsys/webank/domain/UserDocumentsEntity.java
@@ -19,22 +19,22 @@ public class UserDocumentsEntity {
     private String accountId;
 
 
-    @Column(name = "front_id", nullable = true)
+    @Column(name = "front_id", nullable = true, columnDefinition = "TEXT")
     private String frontID;
 
 
-    @Column(name = "back_id", nullable = true)
+    @Column(name = "back_id", nullable = true, columnDefinition = "TEXT")
     private String backID;
 
 
-    @Column(name = "selfie_id", nullable = true)
+    @Column(name = "selfie_id", nullable = true, columnDefinition = "TEXT")
     private String selfieID;
 
 
-    @Column(name = "tax_id", nullable = true)
+    @Column(name = "tax_id", nullable = true, columnDefinition = "TEXT")
     private String taxID;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = true)
+    @Column(name = "status", nullable = true, columnDefinition = "TEXT")
     private UserDocumentsStatus status;
 }


### PR DESCRIPTION
### Description: 

**The current VARCHAR(255) limit on KYC document fields (front_id, back_id, selfie_id, tax_id) is insufficient for storing Base64-encoded images. This change updates the database schema to use TEXT type for those columns and aligns the entity mapping to prevent data truncation errors during submission.** 

**Steps:**  
- Updated UserDocumentsEntity with columnDefinition = "TEXT"
   
     