### PR TITLE
Implement update-or-create logic for KYC documents with PENDING status

### DIFF
--- a/prs/prs-db-repository/src/main/java/com/adorsys/webank/domain/UserDocumentsEntity.java
+++ b/prs/prs-db-repository/src/main/java/com/adorsys/webank/domain/UserDocumentsEntity.java
@@ -35,6 +35,6 @@ public class UserDocumentsEntity {
     private String taxID;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = true, columnDefinition = "TEXT")
+    @Column(name = "status", nullable = true)
     private UserDocumentsStatus status;
 }

--- a/prs/prs-service-impl/src/main/java/com/adorsys/webank/serviceimpl/KycServiceImpl.java
+++ b/prs/prs-service-impl/src/main/java/com/adorsys/webank/serviceimpl/KycServiceImpl.java
@@ -32,15 +32,35 @@ public class KycServiceImpl implements KycServiceApi {
         try {
             log.info("Processing KYC Document for accountId: {}", AccountId);
 
-            UserDocumentsEntity userDocuments = UserDocumentsEntity.builder()
-                    .accountId(AccountId)
-                    .frontID(kycDocumentRequest.getFrontId())
-                    .backID(kycDocumentRequest.getBackId())
-                    .selfieID(kycDocumentRequest.getSelfieId())
-                    .taxID(kycDocumentRequest.getTaxId())
-                    .build();
+            // Check if document already exists
+            Optional<UserDocumentsEntity> existingDocOpt = repository.findByAccountId(AccountId);
+            UserDocumentsEntity userDocuments;
 
+            if (existingDocOpt.isPresent()) {
+                // Update existing document
+                userDocuments = existingDocOpt.get();
+                userDocuments.setFrontID(kycDocumentRequest.getFrontId());
+                userDocuments.setBackID(kycDocumentRequest.getBackId());
+                userDocuments.setSelfieID(kycDocumentRequest.getSelfieId());
+                userDocuments.setTaxID(kycDocumentRequest.getTaxId());
+                userDocuments.setStatus(UserDocumentsStatus.PENDING);
+                log.debug("Updating existing UserDocumentsEntity: {}", userDocuments);
+            } else {
+                // Create new document
+                userDocuments = UserDocumentsEntity.builder()
+                        .accountId(AccountId)
+                        .frontID(kycDocumentRequest.getFrontId())
+                        .backID(kycDocumentRequest.getBackId())
+                        .selfieID(kycDocumentRequest.getSelfieId())
+                        .taxID(kycDocumentRequest.getTaxId())
+                        .status(UserDocumentsStatus.PENDING)
+                        .build();
+                log.debug("Creating new UserDocumentsEntity: {}", userDocuments);
+            }
+
+            // Save to DB
             repository.save(userDocuments);
+            log.info("KYC Document saved successfully for accountId: {}", AccountId);
             return "KYC Document sent successfully and saved";
         } catch (Exception e) {
             log.error("Failed to send KYC Document for accountId: {}", AccountId, e);


### PR DESCRIPTION
#### Description:  

**Currently, submitting a KYC document always creates a new record. This can lead to duplicate entries or inconsistent state when resubmitting documents for the same user.** 

**This change introduces logic to:** 
- Check if a document already exists for the given accountId
- Update it if found
-  Create a new one if not
    
Additionally, all submitted documents are now explicitly set to PENDING status to ensure correct workflow handling. 